### PR TITLE
Add sci tool integration and enhance Weaviate tool documentation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { regESGTool } from './tools/esg.js';
+import { regSciTool } from './tools/sci.js'; // Ensure to import the sci tool if needed
 import { regWeaviateTool } from './tools/weaviate.js';
 
 const server = new McpServer({
@@ -12,6 +13,7 @@ const server = new McpServer({
 
 regWeaviateTool(server);
 regESGTool(server);
+regSciTool(server);
 
 async function runServer() {
   const transport = new StdioServerTransport();

--- a/src/tools/sci.ts
+++ b/src/tools/sci.ts
@@ -1,0 +1,112 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import cleanObject from './_shared/clean_object.js';
+import { base_url, supabase_anon_key, x_api_key, x_region } from './_shared/config.js';
+
+const input_schema = {
+  query: z.string().min(1).describe('Requirements or questions from the user.'),
+  topK: z.number().default(5).describe('Number of top chunk results to return.'),
+  extK: z
+    .number()
+    .default(0)
+    .describe('Number of additional chunks to include before and after each topK result.'),
+  filter: z
+    .object({
+      journal: z.array(z.string()).optional().describe('Filter by journal.'),
+      doi: z.array(z.string()).optional().describe('Filter by DOI.'), // 新增 DOI 筛选条件
+    })
+    .optional()
+    .describe(
+      'DO NOT USE IT IF NOT EXPLICIT REQUESTED IN THE QUERY. Optional filter conditions for specific fields, as an object with optional arrays of values.',
+    ),
+  dateFilter: z
+    .object({
+      date: z
+        .object({
+          gte: z.number().optional(),
+          lte: z.number().optional(),
+        })
+        .optional(),
+    })
+    .optional()
+    .describe(
+      'DO NOT USE IT IF NOT EXPLICIT REQUESTED IN THE QUERY. Optional filter conditions for date ranges in UNIX timestamps.',
+    ),
+};
+
+async function searchSci({
+  query,
+  topK,
+  extK,
+  filter,
+  dateFilter,
+}: {
+  query: string;
+  topK: number;
+  extK: number;
+  filter?: {
+    journal?: string[];
+    doi?: string[];
+  };
+  dateFilter?: {
+    date?: {
+      gte?: number;
+      lte?: number;
+    };
+  };
+}): Promise<string> {
+  const url = `${base_url}/sci_search`;
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${supabase_anon_key}`,
+        'x-api-key': x_api_key,
+        'x-region': x_region,
+      },
+      body: JSON.stringify(
+        cleanObject({
+          query,
+          topK,
+          extK,
+          filter,
+          dateFilter,
+        }),
+      ),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error: ${response.status} ${response.statusText}`);
+    }
+    const data = await response.json();
+    return JSON.stringify(data);
+  } catch (error) {
+    console.error('Error making the request:', error);
+    throw error;
+  }
+}
+
+export function regSciTool(server: McpServer) {
+  server.tool(
+    'Search_Sci_Tool',
+    'Perform search on academic database for precise and specialized information.',
+    input_schema,
+    async ({ query, topK, extK, filter, dateFilter }, extra) => {
+      const result = await searchSci({
+        query,
+        topK,
+        extK,
+        filter,
+        dateFilter,
+      });
+      return {
+        content: [
+          {
+            type: 'text',
+            text: result,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/weaviate.ts
+++ b/src/tools/weaviate.ts
@@ -6,7 +6,32 @@ export function regWeaviateTool(server: McpServer) {
   server.tool(
     'Weaviate Hybrid Search with Extension',
     'Hybrid search in Weaviate with context extension',
-    { collection: z.string(), query: z.string(), topK: z.number(), extK: z.number().min(0) },
+    {
+      collection: z
+        .string()
+        .describe(
+          'The name of the Weaviate collection to query. This should be the name of the collection where your documents are stored.',
+        ),
+      query: z
+        .string()
+        .describe(
+          'The search query or requirements from the user. This is the main input for the hybrid search.',
+        ),
+      topK: z
+        .number()
+        .min(0)
+        .default(5)
+        .describe(
+          'The number of top results to return from the hybrid search. This defines how many objects will be returned from the initial hybrid search query. Default is 5.',
+        ),
+      extK: z
+        .number()
+        .min(0)
+        .default(0)
+        .describe(
+          'The number of additional chunks to include before and after each topK result. This allows for context extension around the top results, providing more comprehensive information. Default is 0.',
+        ),
+    },
     async ({ collection, query, topK, extK }, extra) => {
       const client = await weaviate.connectToCustom({
         httpHost: 'localhost',


### PR DESCRIPTION
@linancn 
This pull request introduces a new scientific search tool and updates the existing Weaviate tool with improved descriptions. The most important changes include adding the `regSciTool` function, importing the necessary dependencies, and enhancing the input schema for the Weaviate tool.

New scientific search tool:

* [`src/tools/sci.ts`](diffhunk://#diff-05780fd588d9662b20e118ac1db9a6127685b4dc95145da623f6a1a3633a2ec7R1-R112): Added a new tool `regSciTool` for performing searches on an academic database, including the implementation of the `searchSci` function and the input schema.

Tool registration and import:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R6): Imported the `regSciTool` and registered it with the `McpServer`. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R6) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R16)

Enhanced input schema descriptions:

* [`src/tools/weaviate.ts`](diffhunk://#diff-d8ccb30072c6d018b6d5124c0c93531d41da6f78076d0848ae03ba07d9d99a1eL9-R34): Updated the input schema for the `regWeaviateTool` function to include detailed descriptions for each field.