### PR TITLE
Add educational tool registration and implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { regESGTool } from './tools/esg.js';
-import { regSciTool } from './tools/sci.js'; // Ensure to import the sci tool if needed
+import { regSciTool } from './tools/sci.js'; 
+import { regEduTool } from './tools/edu.js';
 import { regWeaviateTool } from './tools/weaviate.js';
 
 const server = new McpServer({
@@ -14,6 +15,7 @@ const server = new McpServer({
 regWeaviateTool(server);
 regESGTool(server);
 regSciTool(server);
+regEduTool(server);
 
 async function runServer() {
   const transport = new StdioServerTransport();

--- a/src/tools/edu.ts
+++ b/src/tools/edu.ts
@@ -1,0 +1,90 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import cleanObject from './_shared/clean_object.js';
+import { base_url, supabase_anon_key, x_api_key, x_region } from './_shared/config.js';
+
+const input_schema = {
+  query: z.string().min(1).describe('Requirements or questions from the user.'),
+  topK: z.number().default(5).describe('Number of top chunk results to return.'),
+  extK: z
+    .number()
+    .default(0)
+    .describe('Number of additional chunks to include before and after each topK result.'),
+  filter: z
+    .object({
+      rec_id: z.array(z.string()).optional().describe('Filter by record ID.'),
+      course: z.array(z.string()).optional().describe('Filter by course.'),
+    })
+    .optional()
+    .describe(
+      'DO NOT USE IT IF NOT EXPLICIT REQUESTED IN THE QUERY. Optional filter conditions for specific fields, as an object with optional arrays of values.'
+    ),
+};
+
+async function searchEdu({
+  query,
+  topK,
+  extK,
+  filter,
+}: {
+  query: string;
+  topK: number;
+  extK: number;
+  filter?: {
+    rec_id?: string[];
+    course?: string[];
+  };
+}): Promise<string> {
+  const url = `${base_url}/edu_search`;
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${supabase_anon_key}`,
+        'x-api-key': x_api_key,
+        'x-region': x_region,
+      },
+      body: JSON.stringify(
+        cleanObject({
+          query,
+          topK,
+          extK,
+          filter,
+        })
+      ),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error: ${response.status} ${response.statusText}`);
+    }
+    const data = await response.json();
+    return JSON.stringify(data);
+  } catch (error) {
+    console.error('Error making the request:', error);
+    throw error;
+  }
+}
+
+export function regEduTool(server: McpServer) {
+  server.tool(
+    'Search_Edu_Tool',
+    'Search the environmental educational materials database for information.',
+    input_schema,
+    async ({ query, topK, extK, filter }, extra) => {
+      const result = await searchEdu({
+        query,
+        topK,
+        extK,
+        filter,
+      });
+      return {
+        content: [
+          {
+            type: 'text',
+            text: result,
+          },
+        ],
+      };
+    }
+  );
+}


### PR DESCRIPTION
This pull request introduces a new educational tool (`regEduTool`) to the server, enabling searches in an educational materials database. The changes include adding the tool's registration, defining its schema, and implementing its functionality.

### Addition of the Educational Tool:

* **Tool Registration in `src/index.ts`:**
  - Added import for `regEduTool` and registered it with the server to enable its functionality. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L6-R7) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R18)

* **Implementation of `regEduTool` in `src/tools/edu.ts`:**
  - Defined the `input_schema` using `zod` to validate and describe the tool's input parameters, including query, topK results, additional chunks (extK), and optional filters.
  - Implemented the `searchEdu` function to handle API requests to the educational materials database, including error handling and response parsing.
  - Registered the `Search_Edu_Tool` with the server, linking it to the `searchEdu` function and providing a description of its purpose and input schema.