### PR TITLE
Prevent duplicate chunk IDs from being added to docChunks in Weaviate…

### DIFF
--- a/src/tools/weaviate.ts
+++ b/src/tools/weaviate.ts
@@ -134,7 +134,10 @@ export function regWeaviateTool(server: McpServer) {
           if (!docSources[docUuid]) docSources[docUuid] = source ? String(source) : '';
 
           const contentStr = content ? String(content) : '';
-          docChunks[docUuid].push({ chunkId, content: contentStr });
+          // 去重：只添加未存在的chunkId
+          if (!docChunks[docUuid].some((c) => c.chunkId === chunkId)) {
+            docChunks[docUuid].push({ chunkId, content: contentStr });
+          }
         } else {
           console.error('Invalid fetched chunk:', obj);
         }


### PR DESCRIPTION
This pull request adds a deduplication check to the `regWeaviateTool` function in `src/tools/weaviate.ts`. The change ensures that only unique `chunkId` values are added to the `docChunks` array for a given `docUuid`.

Deduplication improvement:

* [`src/tools/weaviate.ts`](diffhunk://#diff-d8ccb30072c6d018b6d5124c0c93531d41da6f78076d0848ae03ba07d9d99a1eR137-R140): Updated the `regWeaviateTool` function to include a check that prevents adding duplicate `chunkId` entries to the `docChunks` array. This is achieved using the `.some()` method to verify if a `chunkId` already exists before pushing a new chunk.… tool