### PR TITLE
docs: align MCP governance docs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -13,6 +13,7 @@ routing:
         - AGENTS.md
         - AGENTS_ZH.md
         - .docpact/**
+        - .github/workflows/docpact.yml
         - .github/prompts/**
         - _docs/**
     architecture:
@@ -40,6 +41,7 @@ coverage:
     - DEV_EN.md
     - DEV_CN.md
     - .docpact/**
+    - .github/workflows/docpact.yml
     - _docs/**
     - package.json
     - tsconfig.json
@@ -94,6 +96,8 @@ rules:
         kind: localized-agent-contract
       - path: .docpact/config.yaml
         kind: machine-contract
+      - path: .github/workflows/docpact.yml
+        kind: governance-ci
       - path: .github/prompts/**
         kind: agent-prompt
       - path: _docs/**

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,0 +1,176 @@
+version: 1
+layout: repo
+lastReviewedAt: "2026-04-29"
+lastReviewedCommit: "04a3868c3b259fd4fe32b35b8198e20bbf4f329c"
+
+repo:
+  id: mcp
+
+routing:
+  intents:
+    governance:
+      paths:
+        - AGENTS.md
+        - AGENTS_ZH.md
+        - .docpact/**
+        - .github/prompts/**
+        - _docs/**
+    architecture:
+      paths:
+        - src/**
+        - mcp_config.json
+        - tsconfig.json
+    operations:
+      paths:
+        - README.md
+        - README_CN.md
+        - DEV_EN.md
+        - DEV_CN.md
+        - package.json
+        - Dockerfile
+        - .env.example
+        - test.http
+
+coverage:
+  include:
+    - AGENTS.md
+    - AGENTS_ZH.md
+    - README.md
+    - README_CN.md
+    - DEV_EN.md
+    - DEV_CN.md
+    - .docpact/**
+    - _docs/**
+    - package.json
+    - tsconfig.json
+    - Dockerfile
+    - mcp_config.json
+    - .env.example
+    - src/**
+    - test.http
+    - .github/prompts/**
+  exclude:
+    - .git/**
+    - .docpact/runs/**
+    - node_modules/**
+    - dist/**
+    - build/**
+    - coverage/**
+    - .DS_Store
+    - "**/.DS_Store"
+
+docInventory:
+  include:
+    - AGENTS.md
+    - AGENTS_ZH.md
+    - README.md
+    - README_CN.md
+    - DEV_EN.md
+    - DEV_CN.md
+    - .docpact/config.yaml
+    - .github/prompts/**
+    - _docs/**
+  exclude:
+    - .git/**
+    - .docpact/runs/**
+    - node_modules/**
+    - dist/**
+    - build/**
+    - coverage/**
+
+freshness:
+  warn_after_commits: 50
+  warn_after_days: 90
+  critical_after_days: 180
+
+rules:
+  - id: mcp-governance
+    scope: repo
+    repo: mcp
+    triggers:
+      - path: AGENTS.md
+        kind: agent-contract
+      - path: AGENTS_ZH.md
+        kind: localized-agent-contract
+      - path: .docpact/config.yaml
+        kind: machine-contract
+      - path: .github/prompts/**
+        kind: agent-prompt
+      - path: _docs/**
+        kind: governed-docs
+      - path: README.md
+        kind: repo-entry
+      - path: README_CN.md
+        kind: localized-repo-entry
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: AGENTS_ZH.md
+        mode: review_or_update
+      - path: README_CN.md
+        mode: review_or_update
+      - path: .github/prompts/mcp_update_guidelines_en.md
+        mode: review_or_update
+      - path: .github/prompts/mcp_update_guidelines_zh.md
+        mode: review_or_update
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: _docs/README.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+      - path: _docs/standards/documentation-standards.md
+        mode: review_or_update
+    reason: Repository entry guidance, governance config, and documentation standards must remain aligned.
+  - id: mcp-server-surface
+    scope: repo
+    repo: mcp
+    triggers:
+      - path: src/**
+        kind: mcp-source
+      - path: mcp_config.json
+        kind: mcp-client-config
+      - path: tsconfig.json
+        kind: typescript-config
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: README.md
+        mode: review_or_update
+      - path: _docs/architecture/repo-architecture.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+      - path: _docs/runbooks/development.md
+        mode: review_or_update
+    reason: MCP tools, server transport, auth behavior, and TypeScript runtime configuration must stay synchronized with docs.
+  - id: mcp-operations
+    scope: repo
+    repo: mcp
+    triggers:
+      - path: package.json
+        kind: node-workflow
+      - path: Dockerfile
+        kind: deployment-container
+      - path: .env.example
+        kind: environment-template
+      - path: DEV_EN.md
+        kind: developer-guide
+      - path: DEV_CN.md
+        kind: localized-developer-guide
+      - path: test.http
+        kind: api-test-example
+    requiredDocs:
+      - path: README.md
+        mode: review_or_update
+      - path: README_CN.md
+        mode: review_or_update
+      - path: DEV_EN.md
+        mode: review_or_update
+      - path: DEV_CN.md
+        mode: review_or_update
+      - path: _docs/runbooks/development.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+    reason: Build, server, packaging, and environment workflows define operator-facing behavior.

--- a/.github/prompts/mcp_update_guidelines_en.md
+++ b/.github/prompts/mcp_update_guidelines_en.md
@@ -1,3 +1,22 @@
+---
+docType: agent-prompt
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: en
+whenToUse: "When updating MCP tool registration, schemas, auth, or transport behavior."
+whenToUpdate: "When tool inventory, server entry points, validation commands, or agent-facing MCP update guidance changes."
+checkPaths:
+  - AGENTS.md
+  - AGENTS_ZH.md
+  - .docpact/config.yaml
+  - package.json
+  - src/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
 # MCP Update Guidelines
 
 ## Preparation
@@ -25,17 +44,14 @@
   `Search_Sci_Tool` → `sci_search`,\
   `Search_ESG_Tool` → `esg_search`,\
   `Search_Edu_Tool` → `edu_search`.
-- After creating or updating a tool module, register it in `src/_shared/init_server_http.ts` so both STDIO and HTTP servers expose the capability.
+- After creating or updating a tool module, register it in `src/_shared/init_server_http.ts` so the HTTP server exposes the capability.
 
 ## Quality & Verification
 - Add integration coverage in `src/test.ts` or companion files so the MCP Inspector can exercise the new behavior.
-- Run `npm run build` and, where possible, `npm run start:server` with representative credentials to verify end-to-end flow.
+- Run `npm run build` and, where possible, `npx dotenv -e .env -- node dist/src/index_server.js` with representative credentials to verify end-to-end flow.
 - Execute `npm run lint` and address formatting so the distributed prompts remain clean.
 
 ## Documentation & Release
-- Update `AGENTS.md` / `AGENTS_CN.md` and agent handbooks when tool capabilities change or new parameters surface.
-- Note any deployment considerations (Edge Function version bumps, Redis cache changes) in `AGENTS.md` / `AGENTS_CN.md`.
+- Update `AGENTS.md` / `AGENTS_ZH.md` and agent handbooks when tool capabilities change or new parameters surface.
+- Note any deployment considerations (Edge Function version bumps, Redis cache changes) in `AGENTS.md` / `AGENTS_ZH.md`.
 - Before publishing, confirm the built artifact in `dist/src/index_server.js` exposes the new tool via the CLI binary.
-
-## Known Issues
-- MCP Inspector 0.17.2 introduces a regression where empty JSON inputs (for example the `filter` field on `Search_Sci_Tool`) trigger `Cannot read properties of undefined (reading 'trim')`. Pin `@modelcontextprotocol/inspector` to `0.16.8` in `package.json` and reinstall dependencies until an upstream fix is released.

--- a/.github/prompts/mcp_update_guidelines_zh.md
+++ b/.github/prompts/mcp_update_guidelines_zh.md
@@ -1,3 +1,22 @@
+---
+docType: agent-prompt
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: zh-CN
+whenToUse: "When updating MCP tool registration, schemas, auth, or transport behavior."
+whenToUpdate: "When tool inventory, server entry points, validation commands, or agent-facing MCP update guidance changes."
+checkPaths:
+  - AGENTS.md
+  - AGENTS_ZH.md
+  - .docpact/config.yaml
+  - package.json
+  - src/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
 # MCP 更新指引
 
 ## 准备阶段
@@ -25,17 +44,14 @@
   `Search_Sci_Tool` → `sci_search`、\
   `Search_ESG_Tool` → `esg_search`、\
   `Search_Edu_Tool` → `edu_search`。
-- 新增或更新工具后，务必在 `src/_shared/init_server_http.ts` 中完成注册，确保 STDIO 与 HTTP 服务都能暴露能力。
+- 新增或更新工具后，务必在 `src/_shared/init_server_http.ts` 中完成注册，确保 HTTP 服务能暴露能力。
 
 ## 质量验证
 - 在 `src/test.ts` 或配套测试文件中补充场景，方便 MCP Inspector 端到端验证新能力。
-- 运行 `npm run build`，必要时使用有效凭据执行 `npm run start:server` 确认整体链路。
+- 运行 `npm run build`，必要时使用有效凭据执行 `npx dotenv -e .env -- node dist/src/index_server.js` 确认整体链路。
 - 执行 `npm run lint` 并处理格式问题，确保提交的提示文件保持整洁一致。
 
 ## 文档与发布
-- 当工具能力或参数变化时，及时同步到 `AGENTS.md` / `AGENTS_CN.md` 及相关手册。
-- 将部署注意事项（Edge Function 版本、Redis 缓存调整等）记录在 `AGENTS.md` / `AGENTS_CN.md`。
+- 当工具能力或参数变化时，及时同步到 `AGENTS.md` / `AGENTS_ZH.md` 及相关手册。
+- 将部署注意事项（Edge Function 版本、Redis 缓存调整等）记录在 `AGENTS.md` / `AGENTS_ZH.md`。
 - 发布前确认 `dist/src/index_server.js` 中的 CLI 二进制已导出最新工具。
-
-## 已知问题
-- MCP Inspector 0.17.2 存在回归：JSON 表单为空时（例如 `Search_Sci_Tool` 的 `filter` 字段）会抛出 `Cannot read properties of undefined (reading 'trim')`。请在 `package.json` 中将 `@modelcontextprotocol/inspector` 固定为 `0.16.8` 并重新安装依赖，等待上游修复。

--- a/.github/workflows/docpact.yml
+++ b/.github/workflows/docpact.yml
@@ -1,0 +1,40 @@
+name: docpact
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Biaoo/docpact@v0.1.4
+        with:
+          version: 0.1.4
+          args: >
+            validate-config
+            --root .
+            --strict
+
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Biaoo/docpact@v0.1.4
+        with:
+          version: 0.1.4
+          args: >
+            lint
+            --root .
+            --base ${{ github.event.pull_request.base.sha }}
+            --head ${{ github.sha }}
+            --mode enforce

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,62 +1,66 @@
-# TianGong AI MCP – Agent Handbook
+---
+docType: agent-contract
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: en
+whenToUse: "Before editing the MCP server repository."
+whenToUpdate: "When repo entry points, workflow commands, docpact config, MCP tools, auth behavior, or deployment boundaries change."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - .github/prompts/**
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
 
-## Project Overview
-- Provides a Model Context Protocol (MCP) server that exposes TianGong AI search capabilities over the Streamable HTTP transport.
-- The entry point is `src/index_server.ts`, which runs an Express server on `PORT` (default `9277`) and serves a `/mcp` endpoint protected by bearer or `x-api-key` headers.
-- Tools are registered via `src/_shared/init_server_http.ts` and backed by Supabase Edge Functions; results are streamed back to MCP clients.
+# TianGong AI MCP Agent Contract
 
-## Available MCP Tools
-- `Search_ESG_Tool`: Retrieve ESG report chunks; supports `metaContains`, metadata `filter` (record ID, country), and `dateFilter` on `publication_date`. Only apply optional parameters when users explicitly request scoping.
-- `Search_Sci_Tool`: Search academic publications with optional `filter` by journal / DOI plus `dateFilter` on `date`.
-- `Search_Edu_Tool`: Surface environmental education resources; optional `filter` targets `rec_id` or `course`.
-- `Search_Edu_Graph_Tool`: Traverse the education knowledge graph; configure `root` (entry points) and `depth` (hops) to expand related concepts.
-- `Search_Report_Tool`: Explore sustainability and policy reports with optional filters for `rec_id`, `organization`, or `title`.
-- `Search_Green_Deal_Tool`: Query EU Green Deal documentation; optional filters include `rec_id`, `document_id`, `issue_agency`, `tags`, and `title`.
-- `Search_Internal_Tool`: Look up internal knowledge-base content; optional filters allow `rec_id` or `title`.
-- `Search_Patent_Tool`: Search patent abstracts/metadata with optional `filter` on `country` or `title` and `dateFilter` on `publication_date`.
-- `Search_Standard_Tool`: Access environmental / sustainability standards; optional `metaContains`, metadata `filter` (record ID, organization, standard number, title), and `dateFilter` on `effective_date`.
-- `Search_Textbook_Tool`: Retrieve curated environmental textbook material; optional metadata filters (`rec_id`, `title`, `author`, `company_name`, `isbn_number`) plus `dateFilter` on `publication_date`.
-- All tools sanitize optional arguments with `clean_object.ts` before invoking Supabase Edge Functions.
+This repository owns the MCP server surface for TianGong AI. Workspace-level
+submodule policy remains in the root workspace; MCP implementation and
+repo-local documentation belong here.
 
-## Runtime & Dependencies
-- TypeScript project targeting Node.js ≥ 18 (dev docs use Node 22 via `nvm`).
-- Key dependencies: `@modelcontextprotocol/sdk` (MCP transport), `express` (HTTP server), `zod` (input validation), `@supabase/supabase-js` (auth), `@upstash/redis` (token cache).
-- Dev tooling: `typescript`, `prettier`, `dotenv-cli`, `npm-check-updates`, `@modelcontextprotocol/inspector`.
+## Required Load Order
 
-## Environment Configuration
-Set the following variables (see `src/_shared/config.ts`); defaults exist for local prototyping but production should override them:
+1. Read this file.
+2. Read `.docpact/config.yaml`.
+3. Run `docpact route --root . --paths <target-paths> --format json` from this
+   repo root for the files you plan to change.
+4. Read the relevant files under `_docs/contracts/**`, `_docs/architecture/**`,
+   and `_docs/runbooks/**`.
+5. Read the implementation files under `src/**`.
 
-```
-SUPABASE_BASE_URL
-SUPABASE_PUBLISHABLE_KEY
-UPSTASH_REDIS_URL
-UPSTASH_REDIS_TOKEN
-X_REGION
-PORT
-HOST
-LOCAL_DEPLOYMENT_URL / REMOTE_DEPLOYMENT_URL
-LOCAL_LANGSMITH_API_KEY / REMOTE_LANGSMITH_API_KEY
-```
+## Source Of Truth
 
-Authentication expects either:
-1. A bearer token that Supabase recognizes (`supabase.auth.getUser`), or
-2. A base64-encoded JSON `{ "email": "...", "password": "..." }` string which is cached in Upstash Redis after Supabase verification.
+- `.docpact/config.yaml`: machine-readable governance rules, routing aliases,
+  coverage, document inventory, and freshness policy.
+- `README.md`, `README_CN.md`, `DEV_EN.md`, and `DEV_CN.md`: user-facing and
+  developer-facing workflow notes.
+- `_docs/contracts/repo-contract.md`: durable ownership and boundary rules.
+- `_docs/architecture/repo-architecture.md`: current MCP server topology.
+- `_docs/runbooks/development.md`: repeatable build, local server, and
+  validation steps.
 
-## Development Workflow
-1. `npm install` – installs runtime + dev dependencies.
-2. `npm run build` – compiles TypeScript to `dist/` and makes binaries executable.
-3. `npm start` – runs the STDIO MCP server alongside the Inspector for quick local testing.
-4. `npm run start:server` – builds and launches the HTTP server plus Inspector (requires `.env` with auth info).
-5. `npm run lint` – formats with Prettier (configured to write changes).
+## Hard Boundaries
 
-Use `src/test.ts` as a reference client that connects to `http://localhost:9277/mcp` via the streamable HTTP transport.
+- Do not move workspace submodule policy, branch policy, or integration
+  completion rules into this repository.
+- Treat MCP tool schemas, authentication behavior, and response streaming as
+  public integration contracts.
+- Do not commit real Supabase, Upstash, LangSmith, or deployment secrets.
 
-## Deployment Notes
-- Dockerfile builds the server and exposes port `9277`; follow `DEV_EN.md` for AWS ECR publishing commands.
-- NPM package exposes `tiangong-ai-mcp-http` (see `package.json` `bin`) landing in `dist/src/index_server.js`.
-- When publishing, run `npm run build && npm publish` after authenticating with NPM.
+## Completion Criteria
 
-## Additional References
-- Developer guides: `DEV_EN.md`, `DEV_CN.md`.
-- Public README: `README.md` / `README_CN.md`.
-- MCP SDK documentation: <https://modelcontextprotocol.io>
+- Relevant docpact route output has been reviewed before code or docs changes.
+- Docs touched by the route result are reviewed or updated.
+- `docpact validate-config --root . --strict` passes after governance changes.
+- For implementation changes, run the relevant build or server validation from
+  `_docs/runbooks/development.md`.
+
+## Implementation Pointers
+
+For tool names, server entry points, auth, and commands, use
+`_docs/architecture/repo-architecture.md`, `_docs/runbooks/development.md`, and
+`package.json` as the maintained references.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ whenToUpdate: "When repo entry points, workflow commands, docpact config, MCP to
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - .github/prompts/**
   - _docs/**
 lastReviewedAt: 2026-04-29

--- a/AGENTS_ZH.md
+++ b/AGENTS_ZH.md
@@ -1,3 +1,22 @@
+---
+docType: agent-contract
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: zh-CN
+whenToUse: "Before editing the MCP server repository with Chinese-language agent guidance."
+whenToUpdate: "When repo entry points, workflow commands, docpact config, MCP tools, auth behavior, or deployment boundaries change."
+checkPaths:
+  - AGENTS.md
+  - AGENTS_ZH.md
+  - .docpact/config.yaml
+  - .github/prompts/**
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
 # TianGong AI MCP – Agent 指南
 
 ## 项目概览
@@ -45,8 +64,8 @@ LOCAL_LANGSMITH_API_KEY / REMOTE_LANGSMITH_API_KEY
 ## 开发流程
 1. `npm install`：安装依赖。
 2. `npm run build`：编译 TypeScript 到 `dist/` 并调整脚本权限。
-3. `npm start`：启动 STDIO MCP 服务器并打开 MCP Inspector，便于本地快速联调。
-4. `npm run start:server`：构建并启动 HTTP 服务器（需 `.env` 提供认证信息），同时自动打开 Inspector。
+3. `npx dotenv -e .env -- node dist/src/index_server.js`：在 `npm run build` 后启动本地 HTTP MCP 服务器。
+4. `npx @modelcontextprotocol/inspector`：需要交互式调试时单独启动 Inspector。
 5. `npm run lint`：使用 Prettier 自动格式化 / 修复。
 
 `src/test.ts` 给出了如何通过 Streamable HTTP 方式连接 `http://localhost:9277/mcp` 的示例客户端。

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -1,3 +1,24 @@
+---
+docType: runbook
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: zh-CN
+whenToUse: "When setting up, developing, testing, publishing, or deploying the MCP server with Chinese-language guidance."
+whenToUpdate: "When setup, build, local server, publishing, or Docker deployment commands change."
+checkPaths:
+  - README.md
+  - README_CN.md
+  - DEV_EN.md
+  - package.json
+  - Dockerfile
+  - .env.example
+  - src/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
 # TianGong-AI-MCP
 
 [中文](https://github.com/linancn/tiangong-ai-mcp/blob/main/DEV_CN.md) | [English](https://github.com/linancn/tiangong-ai-mcp/blob/main/DEV_EN.md)
@@ -12,9 +33,6 @@ nvm use
 
 # 安装依赖
 npm install
-
-# 更新依赖
-npm update && npm ci
 ```
 
 ## 代码格式化
@@ -26,11 +44,11 @@ npm run lint
 
 ## 本地测试
 
-### STDIO 服务器
+### HTTP 服务器
 
 ```bash
-# 使用 MCP Inspector 启动 STDIO 服务器
-npm run start
+npm run build
+npx dotenv -e .env -- node dist/src/index_server.js
 ```
 
 ### 启动 MCP Inspector
@@ -58,3 +76,5 @@ docker push 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-ai-mcp:latest
 
 docker run -d -p 9277:9277 --env-file .env 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-ai-mcp:latest
 ```
+
+镜像元数据声明 `EXPOSE 80`，但服务默认监听 `PORT=9277`；如部署平台固定端口，请显式设置 `PORT`。

--- a/DEV_EN.md
+++ b/DEV_EN.md
@@ -1,3 +1,24 @@
+---
+docType: runbook
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: en
+whenToUse: "When setting up, developing, testing, publishing, or deploying the MCP server."
+whenToUpdate: "When setup, build, local server, publishing, or Docker deployment commands change."
+checkPaths:
+  - README.md
+  - README_CN.md
+  - DEV_CN.md
+  - package.json
+  - Dockerfile
+  - .env.example
+  - src/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
 # TianGong-AI-MCP
 
 [中文](https://github.com/linancn/tiangong-ai-mcp/blob/main/DEV_CN.md) | [English](https://github.com/linancn/tiangong-ai-mcp/blob/main/DEV_EN.md)
@@ -12,9 +33,6 @@ nvm use
 
 # Install dependencies
 npm install
-
-# Update dependencies
-npm update && npm ci
 ```
 
 ## Code Formatting
@@ -26,11 +44,11 @@ npm run lint
 
 ## Local Testing
 
-### STDIO Server
+### HTTP Server
 
 ```bash
-# Launch the STDIO Server using MCP Inspector
-npm start
+npm run build
+npx dotenv -e .env -- node dist/src/index_server.js
 ```
 
 ### Launch MCP Inspector
@@ -59,3 +77,6 @@ docker push 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-ai-mcp:latest
 
 docker run -d -p 9277:9277 --env-file .env 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-ai-mcp:latest
 ```
+
+The container image metadata exposes port `80`, while the server defaults to
+`PORT=9277`; set `PORT` explicitly if deploying behind a fixed platform port.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
+---
+docType: guide
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: en
+whenToUse: "When installing, configuring, running, or integrating the TianGong AI MCP server."
+whenToUpdate: "When tool behavior, auth, environment variables, package metadata, build commands, or server startup changes."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - package.json
+  - Dockerfile
+  - .env.example
+  - mcp_config.json
+  - test.http
+  - .github/prompts/**
+  - README_CN.md
+  - DEV_EN.md
+  - DEV_CN.md
+  - src/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
 # TianGong-AI-MCP
 
 [中文](https://github.com/linancn/tiangong-ai-mcp/blob/main/README_CN.md) | [English](https://github.com/linancn/tiangong-ai-mcp/blob/main/README.md)
@@ -17,11 +43,14 @@ npx -p @tiangong-ai/mcp-server tiangong-ai-mcp-http
 
 ### Local Development Server
 
-From this repository you can build and launch the HTTP server alongside the Inspector with:
+From this repository you can build and launch the HTTP server with:
 
 ```bash
-npm run start:server
+npm run build
+npx dotenv -e .env -- node dist/src/index_server.js
 ```
+
+Launch the Inspector separately when interactive MCP inspection is needed.
 
 ### Launch MCP Inspector
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,3 +1,30 @@
+---
+docType: guide
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: zh-CN
+whenToUse: "When installing, configuring, running, or integrating the TianGong AI MCP server with Chinese-language guidance."
+whenToUpdate: "When tool behavior, auth, environment variables, package metadata, build commands, or server startup changes."
+checkPaths:
+  - AGENTS.md
+  - AGENTS_ZH.md
+  - .docpact/config.yaml
+  - package.json
+  - Dockerfile
+  - .env.example
+  - mcp_config.json
+  - test.http
+  - .github/prompts/**
+  - README.md
+  - DEV_EN.md
+  - DEV_CN.md
+  - src/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
 # TianGong-AI-MCP
 
 [中文](https://github.com/linancn/tiangong-ai-mcp/blob/main/README_CN.md) | [English](https://github.com/linancn/tiangong-ai-mcp/blob/main/README.md)
@@ -17,11 +44,14 @@ npx -p @tiangong-ai/mcp-server tiangong-ai-mcp-http
 
 ### 本地开发服务器
 
-在仓库本地开发时，可通过以下命令构建并启动 HTTP 服务器，并自动打开 Inspector：
+在仓库本地开发时，可通过以下命令构建并启动 HTTP 服务器：
 
 ```bash
-npm run start:server
+npm run build
+npx dotenv -e .env -- node dist/src/index_server.js
 ```
+
+如需交互式检查 MCP 能力，请单独启动 Inspector。
 
 ### 启动 MCP Inspector
 

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -11,6 +11,7 @@ checkPaths:
   - AGENTS.md
   - AGENTS_ZH.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - .github/prompts/**
   - _docs/**
 lastReviewedAt: 2026-04-29
@@ -27,6 +28,8 @@ low-entropy source-of-truth rules.
 
 - Layer 0: `AGENTS.md` for mandatory agent entry guidance.
 - Layer 1: `.docpact/config.yaml` for machine-readable governance.
+- CI: `.github/workflows/docpact.yml` for config validation and PR
+  documentation lint.
 - Layer 2: current contracts, architecture, standards, and runbooks under
   `_docs/**`.
 - Agent prompts: `.github/prompts/**` for MCP update guidance that is consumed

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -1,0 +1,43 @@
+---
+docType: index
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: en
+whenToUse: "When navigating MCP repository documentation."
+whenToUpdate: "When repository documentation layers, key docs, or governance routing change."
+checkPaths:
+  - AGENTS.md
+  - AGENTS_ZH.md
+  - .docpact/config.yaml
+  - .github/prompts/**
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
+# MCP Documentation
+
+This directory contains the repo-local source documents governed by docpact.
+Agent prompt files under `.github/prompts/**` are governed with the same
+low-entropy source-of-truth rules.
+
+## Layers
+
+- Layer 0: `AGENTS.md` for mandatory agent entry guidance.
+- Layer 1: `.docpact/config.yaml` for machine-readable governance.
+- Layer 2: current contracts, architecture, standards, and runbooks under
+  `_docs/**`.
+- Agent prompts: `.github/prompts/**` for MCP update guidance that is consumed
+  by coding assistants.
+
+## Current Documents
+
+- `_docs/contracts/repo-contract.md`: repository ownership, boundaries, and
+  completion rules.
+- `_docs/architecture/repo-architecture.md`: MCP server topology.
+- `_docs/runbooks/development.md`: build, local server, and validation workflow.
+- `_docs/standards/documentation-standards.md`: repo-local documentation rules.
+- `.github/prompts/mcp_update_guidelines_en.md`: English MCP update prompt.
+- `.github/prompts/mcp_update_guidelines_zh.md`: Chinese MCP update prompt.

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -1,0 +1,50 @@
+---
+docType: architecture
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: en
+whenToUse: "When changing MCP tools, auth, transport, package entry points, or deployment packaging."
+whenToUpdate: "When server topology, tool registration, auth flow, or runtime assumptions change."
+checkPaths:
+  - src/**
+  - package.json
+  - mcp_config.json
+  - Dockerfile
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
+# MCP Architecture
+
+## Overview
+
+The repository provides a TypeScript MCP server for TianGong AI search tools.
+`src/index_server.ts` runs an Express server on `PORT` with a `/mcp` endpoint.
+Tools are registered through shared server initialization code and call
+Supabase Edge Functions.
+
+## Key Paths
+
+- `src/index_server.ts`: Streamable HTTP server entry point.
+- `src/_shared/**`: config, auth, HTTP initialization, and shared helpers.
+- `src/tools/**`: MCP tool definitions and tool-specific schemas.
+- `src/test.ts`: reference client for local server testing.
+- `mcp_config.json`: MCP client/server configuration example.
+- `package.json`: package metadata, binary, scripts, and dependencies.
+- `Dockerfile`: deployment packaging.
+
+## Runtime Shape
+
+The package is an ESM TypeScript project targeting Node.js 18 or newer. Build
+output lands in `dist/`, and the package exposes `tiangong-ai-mcp-http` as a
+binary entry.
+
+## Integration Points
+
+- Incoming clients use the Streamable HTTP transport.
+- Auth accepts Supabase bearer tokens or cached credential verification through
+  Upstash Redis.
+- Tool calls depend on Supabase Edge Functions owned by the edge-function
+  repository.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -1,0 +1,53 @@
+---
+docType: contract
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: en
+whenToUse: "When deciding whether a change belongs in the MCP server repository."
+whenToUpdate: "When ownership, MCP tool contracts, auth boundaries, or completion criteria change."
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - .docpact/config.yaml
+  - src/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
+# MCP Repository Contract
+
+## Ownership
+
+This repository owns the Model Context Protocol server that exposes TianGong AI
+search capabilities over Streamable HTTP and local package entry points. It also
+owns MCP tool schemas, auth handling, server startup, and repo-local deployment
+metadata.
+
+## Boundaries
+
+- Supabase Edge Function implementation belongs in the edge-function repository.
+- Knowledge-base ingestion and document processing belong in the KB and
+  unstructure repositories.
+- Root workspace governance, branch policy, and submodule integration remain in
+  the workspace repository.
+
+## Public Surface
+
+The MCP tool names, Zod schemas, transport endpoint, auth requirements, and
+server binary name are integration contracts. Changes to those surfaces require
+review of:
+
+- `AGENTS.md`
+- `README.md` / `README_CN.md`
+- `_docs/architecture/repo-architecture.md`
+- `_docs/runbooks/development.md`
+
+## Completion Criteria
+
+- Run `docpact route` before editing governed files.
+- Run `docpact validate-config --root . --strict` after governance changes.
+- Run `npm run build` for TypeScript or runtime changes.
+- Run the local HTTP server command from `_docs/runbooks/development.md` or
+  targeted client checks when HTTP transport, auth, or tool behavior changes.

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -1,0 +1,80 @@
+---
+docType: runbook
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: en
+whenToUse: "When developing, validating, or packaging the MCP server."
+whenToUpdate: "When setup, build, local server, auth, or publishing commands change."
+checkPaths:
+  - README.md
+  - DEV_EN.md
+  - DEV_CN.md
+  - package.json
+  - src/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
+# MCP Development Runbook
+
+## Setup
+
+1. Use Node.js 18 or newer; repo development notes use Node.js 22.
+2. Run `npm install`.
+3. Create `.env` from `.env.example` and provide required Supabase, Upstash,
+   region, deployment URL, and optional LangSmith values.
+
+## Build
+
+Run:
+
+```bash
+npm run build
+```
+
+This compiles TypeScript and marks generated server binaries executable.
+
+## Local Server
+
+Run:
+
+```bash
+npm run build
+npx dotenv -e .env -- node dist/src/index_server.js
+```
+
+This starts `dist/src/index_server.js`. Launch the MCP Inspector separately if
+interactive inspection is needed.
+
+## Validation
+
+Run:
+
+```bash
+npm run build
+npm run lint
+docpact validate-config --root . --strict
+```
+
+Use `src/test.ts`, `test.http`, or the MCP Inspector when tool schemas,
+transport, auth, or response behavior changes.
+
+## Container Notes
+
+`Dockerfile` installs `@tiangong-ai/mcp-server@0.0.18` and runs
+`tiangong-ai-mcp-http`. The image metadata exposes port `80`, while
+`src/index_server.ts` defaults to `PORT=9277`; set `PORT` explicitly when the
+runtime platform expects a fixed port.
+
+## Publishing
+
+Before NPM publishing, run:
+
+```bash
+npm run build
+npm publish
+```
+
+Confirm package metadata and binary paths in `package.json` before publishing.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -11,6 +11,7 @@ checkPaths:
   - AGENTS.md
   - AGENTS_ZH.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - .github/prompts/**
   - _docs/**
 lastReviewedAt: 2026-04-29
@@ -24,6 +25,8 @@ lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
 - `AGENTS.md`: mandatory repo entry guidance for agents.
 - `.docpact/config.yaml`: machine-readable governance, routing, coverage, and
   document inventory.
+- `.github/workflows/docpact.yml`: CI enforcement for config validation and PR
+  documentation lint.
 - `_docs/contracts/**`: current constraints and ownership rules.
 - `_docs/architecture/**`: current server topology and integration facts.
 - `_docs/runbooks/**`: executable procedures.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -1,0 +1,44 @@
+---
+docType: standard
+scope: repo
+status: current
+authoritative: true
+owner: mcp
+language: en
+whenToUse: "When creating, moving, or reviewing MCP repository documentation."
+whenToUpdate: "When documentation layers, metadata rules, or source-of-truth boundaries change."
+checkPaths:
+  - AGENTS.md
+  - AGENTS_ZH.md
+  - .docpact/config.yaml
+  - .github/prompts/**
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 04a3868c3b259fd4fe32b35b8198e20bbf4f329c
+---
+
+# MCP Documentation Standards
+
+## Layers
+
+- `AGENTS.md`: mandatory repo entry guidance for agents.
+- `.docpact/config.yaml`: machine-readable governance, routing, coverage, and
+  document inventory.
+- `_docs/contracts/**`: current constraints and ownership rules.
+- `_docs/architecture/**`: current server topology and integration facts.
+- `_docs/runbooks/**`: executable procedures.
+- `_docs/standards/**`: repo-local documentation and engineering standards.
+- `.github/prompts/**`: agent-consumed update guidance for MCP changes.
+
+## Rules
+
+- Keep deterministic governance facts in `.docpact/config.yaml`.
+- Keep explanatory architecture, auth, tool, and workflow details in `_docs/**`.
+- Update docs when MCP tool names, schemas, auth behavior, transport paths,
+  package binaries, or required environment variables change.
+- Keep localized docs aligned when user-visible setup or operational behavior
+  changes.
+- Keep agent prompts aligned with maintained entry points and validation
+  commands; remove stale workaround notes when package metadata has moved on.
+- Do not duplicate root workspace branch policy or submodule integration policy
+  in this repository.


### PR DESCRIPTION
Closes: N/A

## Summary
- Add repo-local docpact config and governed _docs structure.
- Align MCP README, dev docs, agent prompts, and AGENTS guidance with the current HTTP server entry point.

## Key Decisions
- Use dist/src/index_server.js as the maintained local HTTP startup path.
- Govern .github/prompts/** because those files directly shape agent behavior.

## Validation
- docpact validate-config --root tiangong-ai-mcp --strict --format json
- docpact coverage --root tiangong-ai-mcp --format json
- docpact lint --root tiangong-ai-mcp --files AGENTS.md,AGENTS_ZH.md,README.md,README_CN.md,DEV_EN.md,DEV_CN.md,.docpact/config.yaml,_docs/README.md,_docs/standards/documentation-standards.md,_docs/runbooks/development.md,_docs/contracts/repo-contract.md,.github/prompts/mcp_update_guidelines_en.md,.github/prompts/mcp_update_guidelines_zh.md --format json

## Risks / Rollback
- Documentation-only change; rollback by reverting this PR.

## Follow-ups
- None.

## Workspace Integration
- Requires root workspace submodule pin update after merge.